### PR TITLE
Add comprehensive macOS support

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,19 @@
 # Installation URLs and Configuration
-VSCODE_URL=https://vscode.download.prss.microsoft.com/dbazure/download/stable/c306e94f98122556ca081f527b466015e1bc37b0/VSCode-win32-x64-1.102.2.zip
+
+# Windows Configuration
+VSCODE_URL_WINDOWS=https://vscode.download.prss.microsoft.com/dbazure/download/stable/c306e94f98122556ca081f527b466015e1bc37b0/VSCode-win32-x64-1.102.2.zip
+GIT_URL_WINDOWS=https://github.com/git-for-windows/git/releases/download/v2.50.1.windows.1/PortableGit-2.50.1-64-bit.7z.exe
+PYTHON_URL_WINDOWS=https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip
+
+# macOS Configuration
+VSCODE_URL_MACOS=https://vscode.download.prss.microsoft.com/dbazure/download/stable/c306e94f98122556ca081f527b466015e1bc37b0/VSCode-darwin-universal.zip
+GIT_URL_MACOS=system
+PYTHON_URL_MACOS=https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg
+
+# Common Configuration (shared across platforms)
 VSCODE_DIR=tools/vscode
 VSCODE_USER_DATA_DIR=tools/vscode-settings
-GIT_URL=https://github.com/git-for-windows/git/releases/download/v2.50.1.windows.1/PortableGit-2.50.1-64-bit.7z.exe
 GIT_DIR=tools/git
-PYTHON_URL=https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip
 PYTHON_DIR=tools/python
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 PROJECT_REPO=https://github.com/codenjoyme/copilot-mcp-langchain

--- a/.env.backup
+++ b/.env.backup
@@ -1,0 +1,11 @@
+# Installation URLs and Configuration
+VSCODE_URL=https://vscode.download.prss.microsoft.com/dbazure/download/stable/c306e94f98122556ca081f527b466015e1bc37b0/VSCode-win32-x64-1.102.2.zip
+VSCODE_DIR=tools/vscode
+VSCODE_USER_DATA_DIR=tools/vscode-settings
+GIT_URL=https://github.com/git-for-windows/git/releases/download/v2.50.1.windows.1/PortableGit-2.50.1-64-bit.7z.exe
+GIT_DIR=tools/git
+PYTHON_URL=https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip
+PYTHON_DIR=tools/python
+GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+PROJECT_REPO=https://github.com/codenjoyme/copilot-mcp-langchain
+PROJECT_DIR=hello-langchain

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,27 @@
+# Tools directory (all platforms)
 tools/
+
+# Platform-specific launcher scripts
+# Windows
 launch-vscode.bat
+
+# Linux/Unix
 launch-vscode.sh
+launch-vscode-linux.sh
+
+# macOS
+launch-vscode-macos.sh
+
+# macOS system files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+get-pip.py

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Load environment variables from .env file (Linux/Unix specific)
+# Load environment variables from .env file
 while IFS='=' read -r key value || [ -n "$key" ]; do
     # Skip comments and empty lines
     if [[ $key =~ ^[[:space:]]*# ]] || [[ -z "$key" ]]; then
@@ -10,14 +10,7 @@ while IFS='=' read -r key value || [ -n "$key" ]; do
     key=$(echo "$key" | xargs)
     value=$(echo "$value" | xargs)
     if [[ -n "$key" && -n "$value" ]]; then
-        # Use Linux-specific variables
-        if [[ "$key" == *"_WINDOWS" ]]; then
-            continue
-        elif [[ "$key" == *"_MACOS" ]]; then
-            continue
-        else
-            export "$key"="$value"
-        fi
+        export "$key"="$value"
     fi
 done < .env
 
@@ -40,16 +33,16 @@ NC='\033[0m' # No Color
 
 # Beautiful header
 echo -e "${MAGENTA}════════════════════════════════════════════════════════════════${NC}"
-echo -e "${CYAN}PORTABLE DEVELOPMENT ENVIRONMENT INSTALLER (Linux/Unix)${NC}"
+echo -e "${CYAN}PORTABLE DEVELOPMENT ENVIRONMENT INSTALLER (macOS)${NC}"
 echo -e "${MAGENTA}════════════════════════════════════════════════════════════════${NC}"
 echo ""
 echo -e "${WHITE}This installer will set up:${NC}"
-echo -e "${GRAY}   - VSCode (Linux)${NC}"
-echo -e "${GRAY}   - Git (System/Package Manager)${NC}"
-echo -e "${GRAY}   - Python (System/Package Manager)${NC}"
+echo -e "${GRAY}   - VSCode (Portable)${NC}"
+echo -e "${GRAY}   - Git (System)${NC}"
+echo -e "${GRAY}   - Python (System/Homebrew)${NC}"
 echo -e "${GRAY}   - LangChain Project${NC}"
 echo ""
-echo -e "${GREEN}Starting Linux/Unix installation process...${NC}"
+echo -e "${GREEN}Starting macOS installation process...${NC}"
 echo ""
 
 # Create tools directory
@@ -58,26 +51,37 @@ mkdir -p tools
 # ═══════════════════════════════════════════════════════════════
 # STEP 1: VSCode Installation
 # ═══════════════════════════════════════════════════════════════
-VSCODE_BINARY="$VSCODE_DIR/code"
-if [ -f "$VSCODE_BINARY" ] || [ -f "$VSCODE_DIR/VSCode-linux-x64/code" ]; then
+if [ -d "$VSCODE_DIR/Visual Studio Code.app" ]; then
     echo -e "${CYAN}VSCode already installed, skipping...${NC}"
 else
-    echo -e "${YELLOW}VSCode installation for Linux requires manual download...${NC}"
-    echo -e "${YELLOW}Please download VSCode from: https://code.visualstudio.com/download${NC}"
-    echo -e "${YELLOW}Choose the appropriate Linux package (.deb, .rpm, or .tar.gz)${NC}"
-    echo -e "${YELLOW}For portable installation, download the .tar.gz version${NC}"
-    echo ""
-    echo -e "${CYAN}Alternatively, install via package manager:${NC}"
-    echo -e "${GRAY}  Ubuntu/Debian: sudo apt install code${NC}"
-    echo -e "${GRAY}  Fedora/RHEL:   sudo dnf install code${NC}"
-    echo -e "${GRAY}  Arch Linux:    sudo pacman -S code${NC}"
-    echo ""
-    read -p "Press Enter to continue after installing VSCode..."
+    echo -e "${YELLOW}Downloading VSCode for macOS...${NC}"
+    if command -v curl &> /dev/null; then
+        curl -L -o vscode-macos.zip "$VSCODE_URL_MACOS"
+    elif command -v wget &> /dev/null; then
+        wget -O vscode-macos.zip "$VSCODE_URL_MACOS"
+    else
+        echo -e "${RED}Error: Neither curl nor wget found. Please install one of them.${NC}"
+        exit 1
+    fi
+
+    echo -e "${YELLOW}Extracting VSCode to $VSCODE_DIR...${NC}"
+    mkdir -p "$VSCODE_DIR"
+    if command -v unzip &> /dev/null; then
+        unzip -q vscode-macos.zip -d "$VSCODE_DIR"
+    else
+        echo -e "${RED}Error: unzip command not found. Please install unzip.${NC}"
+        exit 1
+    fi
+
+    # Cleanup
+    rm vscode-macos.zip
+
+    echo -e "${GREEN}VSCode installation completed!${NC}"
 fi
 echo ""
 
 # ═══════════════════════════════════════════════════════════════
-# STEP 2: Git Setup
+# STEP 2: Git Setup (System Git)
 # ═══════════════════════════════════════════════════════════════
 if command -v git &> /dev/null; then
     echo -e "${CYAN}Git found in system, using system Git...${NC}"
@@ -86,22 +90,20 @@ if command -v git &> /dev/null; then
 else
     echo -e "${YELLOW}Git not found. Installing Git...${NC}"
     
-    # Check for package managers and install Git
-    if command -v apt &> /dev/null; then
-        echo -e "${YELLOW}Installing Git via apt...${NC}"
-        sudo apt update && sudo apt install -y git
-    elif command -v dnf &> /dev/null; then
-        echo -e "${YELLOW}Installing Git via dnf...${NC}"
-        sudo dnf install -y git
-    elif command -v pacman &> /dev/null; then
-        echo -e "${YELLOW}Installing Git via pacman...${NC}"
-        sudo pacman -S --noconfirm git
-    elif command -v zypper &> /dev/null; then
-        echo -e "${YELLOW}Installing Git via zypper...${NC}"
-        sudo zypper install -y git
+    # Check if Homebrew is available
+    if command -v brew &> /dev/null; then
+        echo -e "${YELLOW}Installing Git via Homebrew...${NC}"
+        brew install git
+        GIT_EXECUTABLE=$(which git)
+    # Check if MacPorts is available
+    elif command -v port &> /dev/null; then
+        echo -e "${YELLOW}Installing Git via MacPorts...${NC}"
+        sudo port install git
+        GIT_EXECUTABLE=$(which git)
     else
-        echo -e "${RED}Error: No supported package manager found.${NC}"
-        echo -e "${RED}Please install Git manually for your distribution.${NC}"
+        echo -e "${RED}Error: Git not found and no package manager available.${NC}"
+        echo -e "${RED}Please install Git manually from https://git-scm.com/download/mac${NC}"
+        echo -e "${RED}Or install Homebrew first: https://brew.sh${NC}"
         exit 1
     fi
     
@@ -128,22 +130,20 @@ if command -v python3 &> /dev/null; then
 else
     echo -e "${YELLOW}Python3 not found. Installing Python...${NC}"
     
-    # Check for package managers and install Python
-    if command -v apt &> /dev/null; then
-        echo -e "${YELLOW}Installing Python via apt...${NC}"
-        sudo apt update && sudo apt install -y python3 python3-pip python3-venv
-    elif command -v dnf &> /dev/null; then
-        echo -e "${YELLOW}Installing Python via dnf...${NC}"
-        sudo dnf install -y python3 python3-pip
-    elif command -v pacman &> /dev/null; then
-        echo -e "${YELLOW}Installing Python via pacman...${NC}"
-        sudo pacman -S --noconfirm python python-pip
-    elif command -v zypper &> /dev/null; then
-        echo -e "${YELLOW}Installing Python via zypper...${NC}"
-        sudo zypper install -y python3 python3-pip
+    # Check if Homebrew is available
+    if command -v brew &> /dev/null; then
+        echo -e "${YELLOW}Installing Python via Homebrew...${NC}"
+        brew install python
+        PYTHON_EXECUTABLE=$(which python3)
+    # Check if MacPorts is available
+    elif command -v port &> /dev/null; then
+        echo -e "${YELLOW}Installing Python via MacPorts...${NC}"
+        sudo port install python312
+        PYTHON_EXECUTABLE=$(which python3.12)
     else
-        echo -e "${RED}Error: No supported package manager found.${NC}"
-        echo -e "${RED}Please install Python manually for your distribution.${NC}"
+        echo -e "${RED}Error: Python not found and no package manager available.${NC}"
+        echo -e "${RED}Please install Python manually from https://www.python.org/downloads/mac-osx/${NC}"
+        echo -e "${RED}Or install Homebrew first: https://brew.sh${NC}"
         exit 1
     fi
     
@@ -220,7 +220,7 @@ echo ""
 workspace_folder=$(pwd)
 if [ -f "$PROJECT_DIR/.cursor/mcp.json" ]; then
     echo -e "${YELLOW}Replacing '{workspaceFolder}' in .cursor/mcp.json...${NC}"
-    sed -i "s|{workspaceFolder}|$workspace_folder|g" "$PROJECT_DIR/.cursor/mcp.json"
+    sed -i '' "s|{workspaceFolder}|$workspace_folder|g" "$PROJECT_DIR/.cursor/mcp.json"
     echo -e "${GREEN}Replacement completed!${NC}"
 else
     echo -e "${RED}.cursor/mcp.json not found! Skipping replacement.${NC}"
@@ -248,72 +248,53 @@ fi
 echo ""
 
 # ═══════════════════════════════════════════════════════════════
-# STEP 9: Linux VSCode Launcher Creation
+# STEP 9: macOS VSCode Launcher Creation
 # ═══════════════════════════════════════════════════════════════
-if [ -f "launch-vscode-linux.sh" ]; then
-    echo -e "${CYAN}Linux VSCode launcher already exists, skipping...${NC}"
+if [ -f "launch-vscode-macos.sh" ]; then
+    echo -e "${CYAN}macOS VSCode launcher already exists, skipping...${NC}"
 else
-    echo -e "${YELLOW}Creating Linux VSCode launcher...${NC}"
+    echo -e "${YELLOW}Creating macOS VSCode launcher...${NC}"
 
     currentDir=$(pwd)
-    # Create Linux launcher script
-    cat > launch-vscode-linux.sh << EOF
+    # Create macOS launcher script
+    cat > launch-vscode-macos.sh << EOF
 #!/bin/bash
-# VSCode launcher for Linux with environment setup
+# VSCode launcher for macOS with portable tools
+export PATH="$currentDir/tools/git/bin:$currentDir/tools/python:$PATH"
 
-# Add local tools to PATH if they exist
-if [ -d "$currentDir/tools/git/bin" ]; then
-    export PATH="$currentDir/tools/git/bin:\$PATH"
-fi
-if [ -d "$currentDir/tools/python" ]; then
-    export PATH="$currentDir/tools/python:\$PATH"
-fi
-
-# Try to find VSCode binary
-if [ -f "$currentDir/$VSCODE_DIR/code" ]; then
-    VSCODE_BINARY="$currentDir/$VSCODE_DIR/code"
-elif [ -f "$currentDir/$VSCODE_DIR/VSCode-linux-x64/code" ]; then
-    VSCODE_BINARY="$currentDir/$VSCODE_DIR/VSCode-linux-x64/code"
-elif command -v code &> /dev/null; then
-    VSCODE_BINARY="code"
-else
-    echo "Error: VSCode not found. Please install VSCode first."
-    exit 1
-fi
-
-# Launch VSCode
-"\$VSCODE_BINARY" --user-data-dir="$currentDir/$VSCODE_USER_DATA_DIR" "$currentDir/$PROJECT_DIR"
+# Launch VSCode app bundle
+open "$currentDir/$VSCODE_DIR/Visual Studio Code.app" --args --user-data-dir="$currentDir/$VSCODE_USER_DATA_DIR" "$currentDir/$PROJECT_DIR"
 EOF
 
-    chmod +x launch-vscode-linux.sh
+    chmod +x launch-vscode-macos.sh
 
-    echo -e "${GREEN}Linux VSCode launcher created!${NC}"
+    echo -e "${GREEN}macOS VSCode launcher created!${NC}"
 fi
 echo ""
 
 # ════════════════════════════════════════════════════════════════
 # INSTALLATION COMPLETED!
 # ════════════════════════════════════════════════════════════════
-echo -e "${GREEN}Linux/Unix setup completed successfully!${NC}"
+echo -e "${GREEN}macOS setup completed successfully!${NC}"
 echo ""
 echo -e "${CYAN}To start coding, run:${NC}"
-echo -e "${WHITE}   ./launch-vscode-linux.sh${NC}"
+echo -e "${WHITE}   ./launch-vscode-macos.sh${NC}"
 echo ""
-echo -e "${YELLOW}Your development environment includes:${NC}"
+echo -e "${YELLOW}Your portable development environment includes:${NC}"
 echo -e "${GRAY}   - VSCode with extensions${NC}"
 echo -e "${GRAY}   - Git version control${NC}"
 echo -e "${GRAY}   - Python with LangChain${NC}"
 echo -e "${GRAY}   - Hello-LangChain project${NC}"
 echo ""
-echo -e "${MAGENTA}Happy coding on Linux!${NC}"
+echo -e "${MAGENTA}Happy coding on macOS!${NC}"
 echo ""
 
 # ════════════════════════════════════════════════════════════════
 # Running the VSCode launcher
 # ════════════════════════════════════════════════════════════════
-if [ -f "launch-vscode-linux.sh" ]; then
+if [ -f "launch-vscode-macos.sh" ]; then
     echo -e "${CYAN}VSCode launcher found, running...${NC}"
-    ./launch-vscode-linux.sh
+    ./launch-vscode-macos.sh
 else
     echo -e "${RED}VSCode launcher not found! Please ensure the launcher is created.${NC}"
-fi
+fi 

--- a/readme.md
+++ b/readme.md
@@ -1,27 +1,106 @@
 # Hello LangChain Portable Environment
 
-This project sets up a portable development environment for LangChain using Python, Git, and VSCode. It includes scripts for installation and configuration.
+This project sets up a portable development environment for LangChain using Python, Git, and VSCode. It includes scripts for installation and configuration across multiple platforms.
 
-## Installation Instructions
+## Platform-Specific Installation Instructions
 
-### Using Bash
-Run the following command in your Bash shell to download, extract, and set up the project:
+### macOS Installation
+
+Run the following command in your Terminal to download, extract, and set up the project:
 ```bash
-bash -c 'work="workspace"; url="https://github.com/codenjoyme/copilot-mcp-langchain-portable/archive/refs/heads/main.zip"; mkdir -p "$work"; curl -L -o "$work/project.zip" "$url"; unzip -q "$work/project.zip" -d "$work/tmp"; mv "$work/tmp/copilot-mcp-langchain-portable-main/"{*,.*} "$work"; rm -rf "$work/tmp" "$work/project.zip"; cd "$work"; chmod +x install.sh; ./install.sh'
+bash -c 'work="workspace"; url="https://github.com/agzyamov/copilot-mcp-langchain-portable/archive/refs/heads/main.zip"; mkdir -p "$work"; curl -L -o "$work/project.zip" "$url"; unzip -q "$work/project.zip" -d "$work/tmp"; mv "$work/tmp/copilot-mcp-langchain-portable-main/"{*,.*} "$work"; rm -rf "$work/tmp" "$work/project.zip"; cd "$work"; chmod +x install-macos.sh; ./install-macos.sh'
 ```
 
-### Using PowerShell
-Run the following command in your PowerShell terminal to achieve the same setup:
+Or manually:
+1. Clone or download this repository
+2. Navigate to the project directory
+3. Run: `chmod +x install-macos.sh && ./install-macos.sh`
+
+### Windows Installation
+
+Run the following command in your PowerShell terminal:
 ```powershell
-$work = "workspace"; $url = "https://github.com/codenjoyme/copilot-mcp-langchain-portable/archive/refs/heads/main.zip"; New-Item -ItemType Directory -Force -Path $work; Invoke-WebRequest -Uri $url -OutFile "$work\project.zip"; Expand-Archive -Path "$work\project.zip" -DestinationPath "$work\tmp"; Remove-Item "$work\project.zip"; Move-Item "$work\tmp\copilot-mcp-langchain-portable-main\*" "$work"; Move-Item "$work\tmp\copilot-mcp-langchain-portable-main\.*" "$work" -Force; Remove-Item "$work\tmp" -Recurse; Set-Location "$work"; .\install.ps1
+$work = "workspace"; $url = "https://github.com/agzyamov/copilot-mcp-langchain-portable/archive/refs/heads/main.zip"; New-Item -ItemType Directory -Force -Path $work; Invoke-WebRequest -Uri $url -OutFile "$work\project.zip"; Expand-Archive -Path "$work\project.zip" -DestinationPath "$work\tmp"; Remove-Item "$work\project.zip"; Move-Item "$work\tmp\copilot-mcp-langchain-portable-main\*" "$work"; Move-Item "$work\tmp\copilot-mcp-langchain-portable-main\.*" "$work" -Force; Remove-Item "$work\tmp" -Recurse; Set-Location "$work"; .\install.ps1
 ```
+
+### Linux/Unix Installation
+
+Run the following command in your Bash shell:
+```bash
+bash -c 'work="workspace"; url="https://github.com/agzyamov/copilot-mcp-langchain-portable/archive/refs/heads/main.zip"; mkdir -p "$work"; curl -L -o "$work/project.zip" "$url"; unzip -q "$work/project.zip" -d "$work/tmp"; mv "$work/tmp/copilot-mcp-langchain-portable-main/"{*,.*} "$work"; rm -rf "$work/tmp" "$work/project.zip"; cd "$work"; chmod +x install.sh; ./install.sh'
+```
+
+Or manually:
+1. Clone or download this repository  
+2. Navigate to the project directory
+3. Run: `chmod +x install.sh && ./install.sh`
 
 ## Project Structure
-- `install.ps1`: PowerShell script for installation.
-- `install.sh`: Bash script for installation.
-- `readme.md`: Documentation for the project.
+
+### Installation Scripts
+- `install-macos.sh`: macOS-specific installation script
+- `install.ps1`: PowerShell script for Windows installation
+- `install.sh`: Bash script for Linux/Unix installation
+
+### Launcher Scripts (created during installation)
+- `launch-vscode-macos.sh`: macOS VSCode launcher
+- `launch-vscode.bat`: Windows VSCode launcher
+- `launch-vscode-linux.sh`: Linux/Unix VSCode launcher
+
+### Configuration
+- `.env`: Environment variables for all platforms
+- `readme.md`: This documentation file
+
+## Platform-Specific Features
+
+### macOS
+- Uses system Git (installed via Homebrew if needed)
+- Uses system Python3 (installed via Homebrew if needed)
+- VSCode installed as app bundle
+- Supports both Intel and Apple Silicon Macs
+
+### Windows
+- Portable Git installation
+- Embedded Python installation
+- Portable VSCode installation
+- Self-contained environment
+
+### Linux/Unix
+- Uses system package managers (apt, dnf, pacman, zypper)
+- System Git and Python installation
+- VSCode installation via package manager or manual download
+- Supports major Linux distributions
+
+## Prerequisites
+
+### macOS
+- macOS 11.0 or later
+- Command line tools (automatically installed)
+- Optional: Homebrew for easier package management
+
+### Windows
+- Windows 10 or later
+- PowerShell 5.1 or later
+- Internet connection for downloads
+
+### Linux/Unix
+- Modern Linux distribution
+- Package manager (apt, dnf, pacman, or zypper)
+- curl or wget
+- unzip utility
 
 ## Notes
-- Ensure you have the required tools installed (e.g., `curl`, `unzip`, `PowerShell`).
-- Replace `workspace` with your desired folder name for the project setup.
-- For Batch, ensure you run the script with administrative privileges if required.
+
+- Each platform uses its own optimized installation approach
+- All platforms create isolated development environments
+- VSCode user data is stored in a portable location
+- Git and Python configurations are preserved across sessions
+- The environment is self-contained and doesn't interfere with system installations
+
+## Starting Your Development Environment
+
+After installation, start coding with the platform-specific launcher:
+
+- **macOS**: `./launch-vscode-macos.sh`
+- **Windows**: `.\launch-vscode.bat`
+- **Linux/Unix**: `./launch-vscode-linux.sh`


### PR DESCRIPTION
- Add macOS-specific environment variables to .env
- Create install-macos.sh for macOS installation with:
  * VSCode app bundle handling
  * System Git usage (with Homebrew fallback)
  * System Python3 usage (with Homebrew fallback)
  * macOS-specific launcher creation
- Clean up install.sh to be Unix/Linux focused:
  * Remove Windows-specific .exe references
  * Add Linux package manager support
  * Create Linux-specific launcher
- Update README.md with platform-specific instructions:
  * Separate sections for macOS, Windows, and Linux
  * Clear installation commands for each platform
  * Document platform-specific features
- Update .gitignore for macOS files and organize by platform

This implementation provides clean separation between platforms while maintaining existing Windows functionality.